### PR TITLE
Bug: Task ID generation should use UUIDs instead of comment-based format

### DIFF
--- a/internal/ai/analyzer.go
+++ b/internal/ai/analyzer.go
@@ -484,12 +484,29 @@ func (a *Analyzer) callClaudeCode(prompt string) ([]TaskRequest, error) {
 	return tasks, nil
 }
 
+// convertToStorageTasks converts AI-generated TaskRequest objects to storage.Task objects.
+//
+// CRITICAL IMPLEMENTATION NOTE:
+// Task IDs MUST be generated using UUIDs for the following reasons:
+// 1. Global uniqueness guarantee
+// 2. Unpredictability for security
+// 3. No dependency on other field values
+// 4. Future-proof design
+//
+// WARNING: DO NOT use comment-based ID formats like "comment-%d-task-%d".
+// This approach is fundamentally flawed and creates collision risks.
+//
+// The current implementation uses comment-based IDs which is a known bug.
+// See GitHub issue: https://github.com/biwakonbu/reviewtask/issues/34
+// TODO: Replace with UUID generation: uuid.New().String()
 func (a *Analyzer) convertToStorageTasks(tasks []TaskRequest) []storage.Task {
 	var result []storage.Task
 	now := time.Now().Format("2006-01-02T15:04:05Z")
 
 	for _, task := range tasks {
 		storageTask := storage.Task{
+			// BUG: This ID generation method is incorrect and must be replaced with UUIDs
+			// See: https://github.com/biwakonbu/reviewtask/issues/34
 			ID:              fmt.Sprintf("comment-%d-task-%d", task.SourceCommentID, task.TaskIndex),
 			Description:     task.Description,
 			OriginText:      task.OriginText,

--- a/internal/ai/analyzer.go
+++ b/internal/ai/analyzer.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"reviewtask/internal/config"
 	"reviewtask/internal/github"
 	"reviewtask/internal/storage"
@@ -486,28 +487,23 @@ func (a *Analyzer) callClaudeCode(prompt string) ([]TaskRequest, error) {
 
 // convertToStorageTasks converts AI-generated TaskRequest objects to storage.Task objects.
 //
-// CRITICAL IMPLEMENTATION NOTE:
-// Task IDs MUST be generated using UUIDs for the following reasons:
-// 1. Global uniqueness guarantee
-// 2. Unpredictability for security
-// 3. No dependency on other field values
-// 4. Future-proof design
+// SPECIFICATION: UUID-based Task ID Generation
+// Task IDs are generated using UUIDs (via uuid.New().String()) to ensure:
+// 1. Global uniqueness guarantee - no collisions possible
+// 2. Unpredictability for security - cannot be guessed
+// 3. No dependency on other field values - future-proof design
+// 4. Standards compliance - follows RFC 4122
 //
-// WARNING: DO NOT use comment-based ID formats like "comment-%d-task-%d".
-// This approach is fundamentally flawed and creates collision risks.
-//
-// The current implementation uses comment-based IDs which is a known bug.
-// See GitHub issue: https://github.com/biwakonbu/reviewtask/issues/34
-// TODO: Replace with UUID generation: uuid.New().String()
+// WARNING: DO NOT revert to comment-based ID formats like "comment-%d-task-%d".
+// Such approaches are fundamentally flawed and create collision risks.
 func (a *Analyzer) convertToStorageTasks(tasks []TaskRequest) []storage.Task {
 	var result []storage.Task
 	now := time.Now().Format("2006-01-02T15:04:05Z")
 
 	for _, task := range tasks {
 		storageTask := storage.Task{
-			// BUG: This ID generation method is incorrect and must be replaced with UUIDs
-			// See: https://github.com/biwakonbu/reviewtask/issues/34
-			ID:              fmt.Sprintf("comment-%d-task-%d", task.SourceCommentID, task.TaskIndex),
+			// UUID-based ID generation ensures global uniqueness and security
+			ID:              uuid.New().String(),
 			Description:     task.Description,
 			OriginText:      task.OriginText,
 			Priority:        task.Priority,

--- a/internal/ai/analyzer_test.go
+++ b/internal/ai/analyzer_test.go
@@ -75,19 +75,19 @@ func TestConvertToStorageTasksUUIDGeneration(t *testing.T) {
 		// Verify other fields are preserved correctly
 		expectedTask := testTasks[i]
 		if task.Description != expectedTask.Description {
-			t.Errorf("Task %d description mismatch: expected '%s', got '%s'", 
+			t.Errorf("Task %d description mismatch: expected '%s', got '%s'",
 				i, expectedTask.Description, task.Description)
 		}
 		if task.OriginText != expectedTask.OriginText {
-			t.Errorf("Task %d origin text mismatch: expected '%s', got '%s'", 
+			t.Errorf("Task %d origin text mismatch: expected '%s', got '%s'",
 				i, expectedTask.OriginText, task.OriginText)
 		}
 		if task.Priority != expectedTask.Priority {
-			t.Errorf("Task %d priority mismatch: expected '%s', got '%s'", 
+			t.Errorf("Task %d priority mismatch: expected '%s', got '%s'",
 				i, expectedTask.Priority, task.Priority)
 		}
 		if task.SourceCommentID != expectedTask.SourceCommentID {
-			t.Errorf("Task %d source comment ID mismatch: expected %d, got %d", 
+			t.Errorf("Task %d source comment ID mismatch: expected %d, got %d",
 				i, expectedTask.SourceCommentID, task.SourceCommentID)
 		}
 	}
@@ -184,7 +184,7 @@ func TestConvertToStorageTasksTimestamps(t *testing.T) {
 
 	// Verify CreatedAt and UpdatedAt are the same for new tasks
 	if task.CreatedAt != task.UpdatedAt {
-		t.Errorf("CreatedAt (%s) and UpdatedAt (%s) should be the same for new tasks", 
+		t.Errorf("CreatedAt (%s) and UpdatedAt (%s) should be the same for new tasks",
 			task.CreatedAt, task.UpdatedAt)
 	}
 

--- a/internal/ai/analyzer_test.go
+++ b/internal/ai/analyzer_test.go
@@ -1,0 +1,426 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"reviewtask/internal/config"
+)
+
+func TestConvertToStorageTasksUUIDGeneration(t *testing.T) {
+	// Create analyzer with default config
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Create test TaskRequest data
+	testTasks := []TaskRequest{
+		{
+			Description:     "Test task 1",
+			OriginText:      "Original comment text 1",
+			Priority:        "high",
+			SourceReviewID:  12345,
+			SourceCommentID: 67890,
+			File:            "test.go",
+			Line:            42,
+			Status:          "todo",
+			TaskIndex:       0,
+		},
+		{
+			Description:     "Test task 2",
+			OriginText:      "Original comment text 2",
+			Priority:        "medium",
+			SourceReviewID:  12345,
+			SourceCommentID: 67890,
+			File:            "test.go",
+			Line:            45,
+			Status:          "todo",
+			TaskIndex:       1,
+		},
+	}
+
+	// Convert to storage tasks
+	storageTasks := analyzer.convertToStorageTasks(testTasks)
+
+	// Verify task count
+	if len(storageTasks) != 2 {
+		t.Errorf("Expected 2 tasks, got %d", len(storageTasks))
+	}
+
+	// Test UUID generation and uniqueness
+	seenIDs := make(map[string]bool)
+	for i, task := range storageTasks {
+		// Verify ID is a valid UUID
+		_, err := uuid.Parse(task.ID)
+		if err != nil {
+			t.Errorf("Task %d ID '%s' is not a valid UUID: %v", i, task.ID, err)
+		}
+
+		// Verify ID uniqueness
+		if seenIDs[task.ID] {
+			t.Errorf("Task %d has duplicate ID '%s'", i, task.ID)
+		}
+		seenIDs[task.ID] = true
+
+		// Verify ID is not the old comment-based format
+		if len(task.ID) < 36 { // UUID v4 is 36 characters with hyphens
+			t.Errorf("Task %d ID '%s' appears to be using old comment-based format", i, task.ID)
+		}
+
+		// Verify other fields are preserved correctly
+		expectedTask := testTasks[i]
+		if task.Description != expectedTask.Description {
+			t.Errorf("Task %d description mismatch: expected '%s', got '%s'", 
+				i, expectedTask.Description, task.Description)
+		}
+		if task.OriginText != expectedTask.OriginText {
+			t.Errorf("Task %d origin text mismatch: expected '%s', got '%s'", 
+				i, expectedTask.OriginText, task.OriginText)
+		}
+		if task.Priority != expectedTask.Priority {
+			t.Errorf("Task %d priority mismatch: expected '%s', got '%s'", 
+				i, expectedTask.Priority, task.Priority)
+		}
+		if task.SourceCommentID != expectedTask.SourceCommentID {
+			t.Errorf("Task %d source comment ID mismatch: expected %d, got %d", 
+				i, expectedTask.SourceCommentID, task.SourceCommentID)
+		}
+	}
+}
+
+func TestConvertToStorageTasksUUIDUniqueness(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Create large number of tasks to test uniqueness at scale
+	const numTasks = 1000
+	testTasks := make([]TaskRequest, numTasks)
+	for i := 0; i < numTasks; i++ {
+		testTasks[i] = TaskRequest{
+			Description:     "Test task",
+			OriginText:      "Original comment text",
+			Priority:        "medium",
+			SourceReviewID:  12345,
+			SourceCommentID: 67890,
+			File:            "test.go",
+			Line:            42,
+			Status:          "todo",
+			TaskIndex:       i,
+		}
+	}
+
+	// Convert to storage tasks
+	storageTasks := analyzer.convertToStorageTasks(testTasks)
+
+	// Verify all IDs are unique
+	seenIDs := make(map[string]bool)
+	for i, task := range storageTasks {
+		if seenIDs[task.ID] {
+			t.Errorf("Task %d has duplicate ID '%s'", i, task.ID)
+		}
+		seenIDs[task.ID] = true
+
+		// Verify each ID is a valid UUID
+		_, err := uuid.Parse(task.ID)
+		if err != nil {
+			t.Errorf("Task %d ID '%s' is not a valid UUID: %v", i, task.ID, err)
+		}
+	}
+
+	// Verify we have exactly the expected number of unique IDs
+	if len(seenIDs) != numTasks {
+		t.Errorf("Expected %d unique IDs, got %d", numTasks, len(seenIDs))
+	}
+}
+
+func TestConvertToStorageTasksTimestamps(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	testTask := TaskRequest{
+		Description:     "Test task",
+		OriginText:      "Original comment text",
+		Priority:        "high",
+		SourceReviewID:  12345,
+		SourceCommentID: 67890,
+		File:            "test.go",
+		Line:            42,
+		Status:          "todo",
+		TaskIndex:       0,
+	}
+
+	// Convert to storage task
+	storageTasks := analyzer.convertToStorageTasks([]TaskRequest{testTask})
+
+	if len(storageTasks) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(storageTasks))
+	}
+
+	task := storageTasks[0]
+
+	// Verify timestamp format is correct
+	_, err := time.Parse("2006-01-02T15:04:05Z", task.CreatedAt)
+	if err != nil {
+		t.Errorf("Invalid CreatedAt timestamp format: %v", err)
+	}
+
+	_, err = time.Parse("2006-01-02T15:04:05Z", task.UpdatedAt)
+	if err != nil {
+		t.Errorf("Invalid UpdatedAt timestamp format: %v", err)
+	}
+
+	// Verify CreatedAt and UpdatedAt are the same for new tasks
+	if task.CreatedAt != task.UpdatedAt {
+		t.Errorf("CreatedAt (%s) and UpdatedAt (%s) should be the same for new tasks", 
+			task.CreatedAt, task.UpdatedAt)
+	}
+
+	// Verify timestamps are not empty
+	if task.CreatedAt == "" {
+		t.Errorf("CreatedAt should not be empty")
+	}
+
+	if task.UpdatedAt == "" {
+		t.Errorf("UpdatedAt should not be empty")
+	}
+}
+
+func TestConvertToStorageTasksEmptyInput(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Test empty input
+	storageTasks := analyzer.convertToStorageTasks([]TaskRequest{})
+
+	if len(storageTasks) != 0 {
+		t.Errorf("Expected 0 tasks for empty input, got %d", len(storageTasks))
+	}
+}
+
+func TestConvertToStorageTasksPreservesAllFields(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "pending",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	testTask := TaskRequest{
+		Description:     "Fix memory leak in parser",
+		OriginText:      "There seems to be a memory leak in the parser when processing large files",
+		Priority:        "critical",
+		SourceReviewID:  98765,
+		SourceCommentID: 11111,
+		File:            "internal/parser/lexer.go",
+		Line:            127,
+		Status:          "todo",
+		TaskIndex:       3,
+	}
+
+	storageTasks := analyzer.convertToStorageTasks([]TaskRequest{testTask})
+
+	if len(storageTasks) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(storageTasks))
+	}
+
+	task := storageTasks[0]
+
+	// Verify all fields are preserved correctly
+	if task.Description != testTask.Description {
+		t.Errorf("Description mismatch: expected '%s', got '%s'", testTask.Description, task.Description)
+	}
+	if task.OriginText != testTask.OriginText {
+		t.Errorf("OriginText mismatch: expected '%s', got '%s'", testTask.OriginText, task.OriginText)
+	}
+	if task.Priority != testTask.Priority {
+		t.Errorf("Priority mismatch: expected '%s', got '%s'", testTask.Priority, task.Priority)
+	}
+	if task.SourceReviewID != testTask.SourceReviewID {
+		t.Errorf("SourceReviewID mismatch: expected %d, got %d", testTask.SourceReviewID, task.SourceReviewID)
+	}
+	if task.SourceCommentID != testTask.SourceCommentID {
+		t.Errorf("SourceCommentID mismatch: expected %d, got %d", testTask.SourceCommentID, task.SourceCommentID)
+	}
+	if task.TaskIndex != testTask.TaskIndex {
+		t.Errorf("TaskIndex mismatch: expected %d, got %d", testTask.TaskIndex, task.TaskIndex)
+	}
+	if task.File != testTask.File {
+		t.Errorf("File mismatch: expected '%s', got '%s'", testTask.File, task.File)
+	}
+	if task.Line != testTask.Line {
+		t.Errorf("Line mismatch: expected %d, got %d", testTask.Line, task.Line)
+	}
+	if task.Status != cfg.TaskSettings.DefaultStatus {
+		t.Errorf("Status mismatch: expected '%s', got '%s'", cfg.TaskSettings.DefaultStatus, task.Status)
+	}
+
+	// Verify ID is a valid UUID
+	_, err := uuid.Parse(task.ID)
+	if err != nil {
+		t.Errorf("Task ID '%s' is not a valid UUID: %v", task.ID, err)
+	}
+}
+
+func TestTaskIDFormatSpecification(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	testTask := TaskRequest{
+		Description:     "Test task for ID format validation",
+		OriginText:      "Original comment text",
+		Priority:        "high",
+		SourceReviewID:  12345,
+		SourceCommentID: 67890,
+		File:            "test.go",
+		Line:            42,
+		Status:          "todo",
+		TaskIndex:       0,
+	}
+
+	storageTasks := analyzer.convertToStorageTasks([]TaskRequest{testTask})
+
+	if len(storageTasks) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(storageTasks))
+	}
+
+	task := storageTasks[0]
+
+	// Test 1: UUID format verification
+	parsedUUID, err := uuid.Parse(task.ID)
+	if err != nil {
+		t.Errorf("Task ID '%s' is not a valid UUID: %v", task.ID, err)
+	}
+
+	// Test 2: UUID version verification (should be version 4)
+	if parsedUUID.Version() != 4 {
+		t.Errorf("Task ID '%s' is not UUID version 4, got version %d", task.ID, parsedUUID.Version())
+	}
+
+	// Test 3: UUID length verification (36 characters with hyphens)
+	if len(task.ID) != 36 {
+		t.Errorf("Task ID '%s' length is %d, expected 36 characters", task.ID, len(task.ID))
+	}
+
+	// Test 4: UUID format pattern verification (8-4-4-4-12)
+	// Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	parts := strings.Split(task.ID, "-")
+	if len(parts) != 5 {
+		t.Errorf("Task ID '%s' should have 5 parts separated by hyphens, got %d parts", task.ID, len(parts))
+	} else {
+		expectedLengths := []int{8, 4, 4, 4, 12}
+		for i, part := range parts {
+			if len(part) != expectedLengths[i] {
+				t.Errorf("Task ID '%s' part %d has length %d, expected %d", task.ID, i+1, len(part), expectedLengths[i])
+			}
+		}
+	}
+
+	// Test 5: Verify ID contains only valid hexadecimal characters and hyphens
+	validChars := "0123456789abcdefABCDEF-"
+	for i, char := range task.ID {
+		if !strings.ContainsRune(validChars, char) {
+			t.Errorf("Task ID '%s' contains invalid character '%c' at position %d", task.ID, char, i)
+		}
+	}
+
+	// Test 6: Verify ID is not old comment-based format
+	if strings.Contains(task.ID, "comment-") || strings.Contains(task.ID, "task-") {
+		t.Errorf("Task ID '%s' appears to use old comment-based format", task.ID)
+	}
+
+	// Test 7: Verify ID is not predictable (no sequential patterns)
+	if strings.Contains(task.ID, "00000000") || strings.Contains(task.ID, "11111111") {
+		t.Errorf("Task ID '%s' contains predictable patterns", task.ID)
+	}
+}
+
+func TestTaskIDUniquenessAcrossMultipleGenerations(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Generate multiple batches of task IDs to test uniqueness across time
+	const numBatches = 10
+	const tasksPerBatch = 100
+	allIDs := make(map[string]bool)
+	totalTasks := 0
+
+	for batch := 0; batch < numBatches; batch++ {
+		// Create identical tasks for each batch
+		testTasks := make([]TaskRequest, tasksPerBatch)
+		for i := 0; i < tasksPerBatch; i++ {
+			testTasks[i] = TaskRequest{
+				Description:     "Uniqueness test task",
+				OriginText:      "Original comment for uniqueness testing",
+				Priority:        "medium",
+				SourceReviewID:  12345,
+				SourceCommentID: 67890,
+				File:            "test.go",
+				Line:            42,
+				Status:          "todo",
+				TaskIndex:       i,
+			}
+		}
+
+		// Convert to storage tasks
+		storageTasks := analyzer.convertToStorageTasks(testTasks)
+
+		// Verify all IDs in this batch are unique
+		batchIDs := make(map[string]bool)
+		for _, task := range storageTasks {
+			// Check uniqueness within batch
+			if batchIDs[task.ID] {
+				t.Errorf("Batch %d: Duplicate ID within batch: %s", batch, task.ID)
+			}
+			batchIDs[task.ID] = true
+
+			// Check uniqueness across all batches
+			if allIDs[task.ID] {
+				t.Errorf("Batch %d: ID collision across batches: %s", batch, task.ID)
+			}
+			allIDs[task.ID] = true
+			totalTasks++
+
+			// Verify ID format for each task
+			_, err := uuid.Parse(task.ID)
+			if err != nil {
+				t.Errorf("Batch %d: Invalid UUID format: %s", batch, task.ID)
+			}
+		}
+	}
+
+	expectedTotal := numBatches * tasksPerBatch
+	if totalTasks != expectedTotal {
+		t.Errorf("Expected %d total tasks, got %d", expectedTotal, totalTasks)
+	}
+
+	if len(allIDs) != totalTasks {
+		t.Errorf("UUID uniqueness failed: expected %d unique IDs, got %d", totalTasks, len(allIDs))
+	}
+
+	t.Logf("Successfully generated %d unique UUID task IDs across %d batches", totalTasks, numBatches)
+}

--- a/internal/ai/integration_test.go
+++ b/internal/ai/integration_test.go
@@ -14,16 +14,16 @@ func TestTaskGenerationIntegrationWithUUIDs(t *testing.T) {
 	// Create test configuration
 	cfg := &config.Config{
 		TaskSettings: config.TaskSettings{
-			DefaultStatus:    "todo",
-			AutoPrioritize:   false,
+			DefaultStatus:  "todo",
+			AutoPrioritize: false,
 		},
 		AISettings: config.AISettings{
-			UserLanguage:        "English",
-			OutputFormat:        "json",
-			MaxRetries:          1, // Limit retries for testing
-			ValidationEnabled:   &[]bool{false}[0], // Disable validation for integration test
-			QualityThreshold:    0.8,
-			DebugMode:          false,
+			UserLanguage:      "English",
+			OutputFormat:      "json",
+			MaxRetries:        1,                 // Limit retries for testing
+			ValidationEnabled: &[]bool{false}[0], // Disable validation for integration test
+			QualityThreshold:  0.8,
+			DebugMode:         false,
 		},
 	}
 
@@ -83,7 +83,7 @@ func TestTaskGenerationIntegrationWithUUIDs(t *testing.T) {
 
 		// Verify task contains expected data from mock reviews
 		if task.SourceReviewID != 12345 {
-			t.Errorf("Integration test task %d has wrong SourceReviewID: expected 12345, got %d", 
+			t.Errorf("Integration test task %d has wrong SourceReviewID: expected 12345, got %d",
 				i, task.SourceReviewID)
 		}
 
@@ -94,7 +94,7 @@ func TestTaskGenerationIntegrationWithUUIDs(t *testing.T) {
 
 		// Verify status is set to default
 		if task.Status != cfg.TaskSettings.DefaultStatus {
-			t.Errorf("Integration test task %d has wrong status: expected '%s', got '%s'", 
+			t.Errorf("Integration test task %d has wrong status: expected '%s', got '%s'",
 				i, cfg.TaskSettings.DefaultStatus, task.Status)
 		}
 	}
@@ -215,11 +215,11 @@ func TestUUIDCollisionResistance(t *testing.T) {
 	}
 
 	if len(allGeneratedIDs) != totalIDs {
-		t.Errorf("Collision test: UUID uniqueness failed - expected %d unique IDs, got %d", 
+		t.Errorf("Collision test: UUID uniqueness failed - expected %d unique IDs, got %d",
 			totalIDs, len(allGeneratedIDs))
 	}
 
-	t.Logf("Collision test: Generated %d unique UUIDs across %d iterations with identical input data", 
+	t.Logf("Collision test: Generated %d unique UUIDs across %d iterations with identical input data",
 		totalIDs, numIterations)
 }
 
@@ -309,7 +309,7 @@ func TestTaskGenerationWithVariousCommentStructures(t *testing.T) {
 			storageTasks := analyzer.convertToStorageTasks(tc.tasks)
 
 			if len(storageTasks) != len(tc.tasks) {
-				t.Errorf("Test case '%s': expected %d tasks, got %d", 
+				t.Errorf("Test case '%s': expected %d tasks, got %d",
 					tc.name, len(tc.tasks), len(storageTasks))
 			}
 
@@ -319,7 +319,7 @@ func TestTaskGenerationWithVariousCommentStructures(t *testing.T) {
 				// Verify UUID validity
 				_, err := uuid.Parse(task.ID)
 				if err != nil {
-					t.Errorf("Test case '%s': task %d has invalid UUID '%s': %v", 
+					t.Errorf("Test case '%s': task %d has invalid UUID '%s': %v",
 						tc.name, i, task.ID, err)
 				}
 

--- a/internal/ai/integration_test.go
+++ b/internal/ai/integration_test.go
@@ -1,0 +1,334 @@
+package ai
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"reviewtask/internal/config"
+)
+
+// TestTaskGenerationIntegrationWithUUIDs tests the complete task generation workflow
+// to ensure UUID generation works correctly in the full pipeline
+func TestTaskGenerationIntegrationWithUUIDs(t *testing.T) {
+	// Create test configuration
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus:    "todo",
+			AutoPrioritize:   false,
+		},
+		AISettings: config.AISettings{
+			UserLanguage:        "English",
+			OutputFormat:        "json",
+			MaxRetries:          1, // Limit retries for testing
+			ValidationEnabled:   &[]bool{false}[0], // Disable validation for integration test
+			QualityThreshold:    0.8,
+			DebugMode:          false,
+		},
+	}
+
+	analyzer := NewAnalyzer(cfg)
+
+	// Test the conversion process directly (since we can't mock Claude Code CLI easily)
+	mockTaskRequests := []TaskRequest{
+		{
+			Description:     "Improve error handling in main function",
+			OriginText:      "This function needs better error handling",
+			Priority:        "high",
+			SourceReviewID:  12345,
+			SourceCommentID: 67890,
+			File:            "main.go",
+			Line:            42,
+			TaskIndex:       0,
+		},
+		{
+			Description:     "Add input validation to utility function",
+			OriginText:      "Consider adding input validation here",
+			Priority:        "medium",
+			SourceReviewID:  12345,
+			SourceCommentID: 67891,
+			File:            "utils.go",
+			Line:            15,
+			TaskIndex:       0,
+		},
+	}
+
+	// Convert to storage tasks
+	storageTasks := analyzer.convertToStorageTasks(mockTaskRequests)
+
+	// Integration test assertions
+	if len(storageTasks) != 2 {
+		t.Errorf("Expected 2 tasks from integration test, got %d", len(storageTasks))
+	}
+
+	// Verify each task has a unique, valid UUID
+	seenIDs := make(map[string]bool)
+	for i, task := range storageTasks {
+		// Verify UUID format and validity
+		parsedUUID, err := uuid.Parse(task.ID)
+		if err != nil {
+			t.Errorf("Integration test task %d has invalid UUID '%s': %v", i, task.ID, err)
+		}
+
+		// Verify UUID version (should be v4)
+		if parsedUUID.Version() != 4 {
+			t.Errorf("Integration test task %d UUID '%s' is not version 4", i, task.ID)
+		}
+
+		// Verify uniqueness
+		if seenIDs[task.ID] {
+			t.Errorf("Integration test found duplicate UUID '%s'", task.ID)
+		}
+		seenIDs[task.ID] = true
+
+		// Verify task contains expected data from mock reviews
+		if task.SourceReviewID != 12345 {
+			t.Errorf("Integration test task %d has wrong SourceReviewID: expected 12345, got %d", 
+				i, task.SourceReviewID)
+		}
+
+		// Verify timestamps are set
+		if task.CreatedAt == "" || task.UpdatedAt == "" {
+			t.Errorf("Integration test task %d missing timestamps", i)
+		}
+
+		// Verify status is set to default
+		if task.Status != cfg.TaskSettings.DefaultStatus {
+			t.Errorf("Integration test task %d has wrong status: expected '%s', got '%s'", 
+				i, cfg.TaskSettings.DefaultStatus, task.Status)
+		}
+	}
+}
+
+// TestUUIDGenerationPerformance tests UUID generation performance at scale
+func TestUUIDGenerationPerformance(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Create a large number of task requests
+	const numTasks = 10000
+	taskRequests := make([]TaskRequest, numTasks)
+	for i := 0; i < numTasks; i++ {
+		taskRequests[i] = TaskRequest{
+			Description:     "Performance test task",
+			OriginText:      "Original comment for performance testing",
+			Priority:        "medium",
+			SourceReviewID:  12345,
+			SourceCommentID: int64(67890 + i),
+			File:            "test.go",
+			Line:            42,
+			TaskIndex:       0,
+		}
+	}
+
+	// Measure conversion time
+	startTime := time.Now()
+	storageTasks := analyzer.convertToStorageTasks(taskRequests)
+	duration := time.Since(startTime)
+
+	// Performance assertions
+	if len(storageTasks) != numTasks {
+		t.Errorf("Performance test: expected %d tasks, got %d", numTasks, len(storageTasks))
+	}
+
+	// Should complete within reasonable time (adjust threshold as needed)
+	if duration > 5*time.Second {
+		t.Errorf("Performance test: UUID generation took too long: %v", duration)
+	}
+
+	// Verify all UUIDs are unique and valid
+	seenIDs := make(map[string]bool)
+	for i, task := range storageTasks {
+		if seenIDs[task.ID] {
+			t.Errorf("Performance test: duplicate UUID found at index %d: %s", i, task.ID)
+		}
+		seenIDs[task.ID] = true
+
+		_, err := uuid.Parse(task.ID)
+		if err != nil {
+			t.Errorf("Performance test: invalid UUID at index %d: %s", i, task.ID)
+		}
+	}
+
+	t.Logf("Performance test: Generated %d unique UUIDs in %v", numTasks, duration)
+}
+
+// TestUUIDCollisionResistance tests that UUID generation is collision-resistant
+func TestUUIDCollisionResistance(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Generate UUIDs multiple times with identical input data
+	const numIterations = 100
+	const numTasksPerIteration = 50
+
+	allGeneratedIDs := make(map[string]bool)
+	totalIDs := 0
+
+	for iteration := 0; iteration < numIterations; iteration++ {
+		// Create identical task requests for each iteration
+		taskRequests := make([]TaskRequest, numTasksPerIteration)
+		for i := 0; i < numTasksPerIteration; i++ {
+			taskRequests[i] = TaskRequest{
+				Description:     "Collision test task",
+				OriginText:      "Identical original comment text",
+				Priority:        "medium",
+				SourceReviewID:  12345,
+				SourceCommentID: 67890, // Same comment ID for all
+				File:            "test.go",
+				Line:            42,
+				TaskIndex:       i,
+			}
+		}
+
+		// Convert to storage tasks
+		storageTasks := analyzer.convertToStorageTasks(taskRequests)
+
+		// Check for collisions within this iteration
+		iterationIDs := make(map[string]bool)
+		for _, task := range storageTasks {
+			if iterationIDs[task.ID] {
+				t.Errorf("Collision test: duplicate UUID within iteration %d: %s", iteration, task.ID)
+			}
+			iterationIDs[task.ID] = true
+
+			// Check for collisions across all iterations
+			if allGeneratedIDs[task.ID] {
+				t.Errorf("Collision test: UUID collision across iterations: %s", task.ID)
+			}
+			allGeneratedIDs[task.ID] = true
+			totalIDs++
+		}
+	}
+
+	expectedTotalIDs := numIterations * numTasksPerIteration
+	if totalIDs != expectedTotalIDs {
+		t.Errorf("Collision test: expected %d total IDs, got %d", expectedTotalIDs, totalIDs)
+	}
+
+	if len(allGeneratedIDs) != totalIDs {
+		t.Errorf("Collision test: UUID uniqueness failed - expected %d unique IDs, got %d", 
+			totalIDs, len(allGeneratedIDs))
+	}
+
+	t.Logf("Collision test: Generated %d unique UUIDs across %d iterations with identical input data", 
+		totalIDs, numIterations)
+}
+
+// TestTaskGenerationWithVariousCommentStructures tests UUID generation with different comment structures
+func TestTaskGenerationWithVariousCommentStructures(t *testing.T) {
+	cfg := &config.Config{
+		TaskSettings: config.TaskSettings{
+			DefaultStatus: "todo",
+		},
+	}
+	analyzer := NewAnalyzer(cfg)
+
+	// Test various comment structures that might occur in real usage
+	testCases := []struct {
+		name  string
+		tasks []TaskRequest
+	}{
+		{
+			name: "Single comment, single task",
+			tasks: []TaskRequest{
+				{
+					Description:     "Fix the bug",
+					OriginText:      "There's a bug here",
+					Priority:        "high",
+					SourceReviewID:  12345,
+					SourceCommentID: 67890,
+					File:            "main.go",
+					Line:            42,
+					TaskIndex:       0,
+				},
+			},
+		},
+		{
+			name: "Single comment, multiple tasks",
+			tasks: []TaskRequest{
+				{
+					Description:     "Fix memory leak",
+					OriginText:      "This code has a memory leak and also needs better error handling",
+					Priority:        "critical",
+					SourceReviewID:  12345,
+					SourceCommentID: 67891,
+					File:            "memory.go",
+					Line:            15,
+					TaskIndex:       0,
+				},
+				{
+					Description:     "Improve error handling",
+					OriginText:      "This code has a memory leak and also needs better error handling",
+					Priority:        "high",
+					SourceReviewID:  12345,
+					SourceCommentID: 67891,
+					File:            "memory.go",
+					Line:            15,
+					TaskIndex:       1,
+				},
+			},
+		},
+		{
+			name: "Multiple comments from same review",
+			tasks: []TaskRequest{
+				{
+					Description:     "Add documentation",
+					OriginText:      "This function needs documentation",
+					Priority:        "medium",
+					SourceReviewID:  12345,
+					SourceCommentID: 67892,
+					File:            "utils.go",
+					Line:            25,
+					TaskIndex:       0,
+				},
+				{
+					Description:     "Fix naming convention",
+					OriginText:      "Variable name should follow camelCase",
+					Priority:        "low",
+					SourceReviewID:  12345,
+					SourceCommentID: 67893,
+					File:            "utils.go",
+					Line:            30,
+					TaskIndex:       0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storageTasks := analyzer.convertToStorageTasks(tc.tasks)
+
+			if len(storageTasks) != len(tc.tasks) {
+				t.Errorf("Test case '%s': expected %d tasks, got %d", 
+					tc.name, len(tc.tasks), len(storageTasks))
+			}
+
+			// Verify all UUIDs are unique and valid
+			seenIDs := make(map[string]bool)
+			for i, task := range storageTasks {
+				// Verify UUID validity
+				_, err := uuid.Parse(task.ID)
+				if err != nil {
+					t.Errorf("Test case '%s': task %d has invalid UUID '%s': %v", 
+						tc.name, i, task.ID, err)
+				}
+
+				// Verify uniqueness
+				if seenIDs[task.ID] {
+					t.Errorf("Test case '%s': duplicate UUID found: %s", tc.name, task.ID)
+				}
+				seenIDs[task.ID] = true
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses Issue #34 by replacing the predictable comment-based task ID generation with UUID-based IDs to ensure global uniqueness and improve security.

**Closes #34**

## Problem Statement

The current implementation in `internal/ai/analyzer.go` generates task IDs using a predictable format:
```go
ID: fmt.Sprintf("comment-%d-task-%d", task.SourceCommentID, task.TaskIndex),
```

This approach has critical issues:
- **Predictable IDs**: Task IDs can be guessed
- **Collision Risk**: Multiple comments could potentially generate the same ID
- **Poor Design**: Task IDs should be globally unique identifiers
- **Maintainability**: Changes to comment structure could break existing task references

## Solution

Replace the current ID generation with UUID generation:
```go
import "github.com/google/uuid"

// In convertToStorageTasks function:
ID: uuid.New().String(),
```

## Implementation Plan

- [ ] Add UUID dependency to go.mod
- [ ] Replace comment-based ID generation with UUID generation
- [ ] Add comprehensive documentation explaining UUID-based ID assignment specification
- [ ] Add warning comments about not using the old comment-based format
- [ ] Create comprehensive unit tests for task ID generation
- [ ] Create integration tests to verify UUID uniqueness
- [ ] Ensure all tests pass with >90% coverage

## Test Plan

- Unit tests for UUID generation uniqueness
- Integration tests for task creation workflow
- Verification that generated IDs are valid UUIDs
- Performance testing for ID generation at scale

🤖 Generated with [Claude Code](https://claude.ai/code)