### PR TITLE
Fix duplicate status and show commands in help output

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -25,7 +25,7 @@ If no TASK_ID is provided, shows the current task (doing status) or next task (t
 }
 
 func init() {
-	rootCmd.AddCommand(showCmd)
+	// No command registration needed here - done in root.go
 }
 
 func runShow(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -225,8 +225,6 @@ func calculateTaskStats(tasks []storage.Task) TaskStats {
 }
 
 func init() {
-	rootCmd.AddCommand(statusCmd)
-
 	// Add flags
 	statusCmd.Flags().BoolVar(&statusShowAll, "all", false, "Show tasks for all PRs")
 	statusCmd.Flags().IntVar(&statusSpecificPR, "pr", 0, "Show tasks for specific PR number")


### PR DESCRIPTION
## Description

This PR fixes #45 by resolving the issue where status and show commands appear twice in the help output.

## Problem
When running `reviewtask --help`, the commands list showed duplicate entries for:
- `status` command appeared twice
- `show` command appeared twice

## Root Cause
The issue was caused by duplicate command registration:
- Commands were being registered in both `cmd/root.go` and their respective command files (`cmd/status.go` and `cmd/show.go`)
- The `init()` functions in both files called `rootCmd.AddCommand()`, causing the duplication

## Solution
- Removed `rootCmd.AddCommand()` calls from `cmd/status.go` and `cmd/show.go` init() functions
- Commands are now only registered once in `cmd/root.go`, following the pattern used by other commands
- The init() functions in command files now only handle flag registration

## Testing
- [x] Verified help output shows each command only once
- [ ] Add unit tests to prevent regression

## Checklist
- [x] Identify root cause of duplicate command registration
- [x] Fix duplicate command issue
- [x] Verify help output shows each command only once
- [ ] Add tests to prevent regression
- [ ] Update documentation if needed

Closes #45