### PR TITLE
Replace Japanese messages with English in status command

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -131,10 +131,10 @@ func displayAIModeEmpty() error {
 	fmt.Println("  todo: 0    doing: 0    done: 0    pending: 0    cancel: 0")
 	fmt.Println()
 	fmt.Println("Current Task:")
-	fmt.Println("  アクティブなタスクはありません - すべて完了しています！")
+	fmt.Println("  No active tasks - all completed!")
 	fmt.Println()
 	fmt.Println("Next Tasks:")
-	fmt.Println("  待機中のタスクはありません")
+	fmt.Println("  No pending tasks")
 	fmt.Println()
 	fmt.Printf("Last updated: %s\n", time.Now().Format("15:04:05"))
 	return nil
@@ -169,7 +169,7 @@ func displayAIModeContent(allTasks []storage.Task, contextDescription string) er
 	fmt.Println("Current Task:")
 	doingTasks := tasks.FilterTasksByStatus(allTasks, "doing")
 	if len(doingTasks) == 0 {
-		fmt.Println("  アクティブなタスクはありません")
+		fmt.Println("  No active tasks")
 	} else {
 		// Show first doing task with work order format: 着手順, ID, Priority, Title
 		task := doingTasks[0]
@@ -183,7 +183,7 @@ func displayAIModeContent(allTasks []storage.Task, contextDescription string) er
 	tasks.SortTasksByPriority(todoTasks)
 
 	if len(todoTasks) == 0 {
-		fmt.Println("  待機中のタスクはありません")
+		fmt.Println("  No pending tasks")
 	} else {
 		// Show top 5 tasks with work order format: 着手順, ID, Priority, Title
 		maxDisplay := 5

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -569,6 +569,71 @@ func TestDisplayAIModeContent(t *testing.T) {
 	assert.Contains(t, output, "2. TSK-123  MEDIUM    Update documentation")
 }
 
+// TestEnglishMessagesInAIModeNoActiveTasks verifies English messages when no active tasks
+func TestEnglishMessagesInAIModeNoActiveTasks(t *testing.T) {
+	testCases := []struct {
+		name          string
+		tasks         []storage.Task
+		expectedMsg1  string
+		expectedMsg2  string
+	}{
+		{
+			name: "No doing tasks but has todo tasks",
+			tasks: []storage.Task{
+				{ID: "1", Status: "todo", Priority: "high", PRNumber: 1},
+				{ID: "2", Status: "done", Priority: "low", PRNumber: 1},
+			},
+			expectedMsg1: "No active tasks",
+			expectedMsg2: "HIGH",
+		},
+		{
+			name: "No todo tasks but has doing tasks",
+			tasks: []storage.Task{
+				{ID: "1", Status: "doing", Priority: "high", PRNumber: 1},
+				{ID: "2", Status: "done", Priority: "low", PRNumber: 1},
+			},
+			expectedMsg1: "HIGH",
+			expectedMsg2: "No pending tasks",
+		},
+		{
+			name: "Only completed tasks",
+			tasks: []storage.Task{
+				{ID: "1", Status: "done", Priority: "high", PRNumber: 1},
+				{ID: "2", Status: "cancel", Priority: "low", PRNumber: 1},
+			},
+			expectedMsg1: "No active tasks",
+			expectedMsg2: "No pending tasks",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Capture stdout
+			old := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			err := displayAIModeContent(tc.tasks, "test")
+			require.NoError(t, err)
+
+			w.Close()
+			os.Stdout = old
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			output := buf.String()
+
+			// Verify expected messages appear
+			assert.Contains(t, output, tc.expectedMsg1)
+			assert.Contains(t, output, tc.expectedMsg2)
+			
+			// Ensure no Japanese messages appear
+			assert.NotContains(t, output, "アクティブなタスクはありません")
+			assert.NotContains(t, output, "待機中のタスクはありません")
+		})
+	}
+}
+
 // TestGenerateTaskID tests task ID generation
 func TestGenerateTaskID(t *testing.T) {
 	testCases := []struct {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -572,10 +572,10 @@ func TestDisplayAIModeContent(t *testing.T) {
 // TestEnglishMessagesInAIModeNoActiveTasks verifies English messages when no active tasks
 func TestEnglishMessagesInAIModeNoActiveTasks(t *testing.T) {
 	testCases := []struct {
-		name          string
-		tasks         []storage.Task
-		expectedMsg1  string
-		expectedMsg2  string
+		name         string
+		tasks        []storage.Task
+		expectedMsg1 string
+		expectedMsg2 string
 	}{
 		{
 			name: "No doing tasks but has todo tasks",
@@ -626,7 +626,7 @@ func TestEnglishMessagesInAIModeNoActiveTasks(t *testing.T) {
 			// Verify expected messages appear
 			assert.Contains(t, output, tc.expectedMsg1)
 			assert.Contains(t, output, tc.expectedMsg2)
-			
+
 			// Ensure no Japanese messages appear
 			assert.NotContains(t, output, "アクティブなタスクはありません")
 			assert.NotContains(t, output, "待機中のタスクはありません")

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -476,8 +476,8 @@ func TestDisplayAIModeEmpty(t *testing.T) {
 	assert.Contains(t, output, "ReviewTask Status - 0% Complete")
 	assert.Contains(t, output, strings.Repeat("░", 80))
 	assert.Contains(t, output, "todo: 0    doing: 0    done: 0    pending: 0    cancel: 0")
-	assert.Contains(t, output, "アクティブなタスクはありません - すべて完了しています！")
-	assert.Contains(t, output, "待機中のタスクはありません")
+	assert.Contains(t, output, "No active tasks - all completed!")
+	assert.Contains(t, output, "No pending tasks")
 	assert.Contains(t, output, "Last updated:")
 }
 

--- a/test/status_tui_integration_test.go
+++ b/test/status_tui_integration_test.go
@@ -198,8 +198,8 @@ func TestStatusCommandIntegration(t *testing.T) {
 		assert.Contains(t, outputStr, "ReviewTask Status - 0% Complete")
 		assert.Contains(t, outputStr, strings.Repeat("░", 80))
 		assert.Contains(t, outputStr, "todo: 0    doing: 0    done: 0    pending: 0    cancel: 0")
-		assert.Contains(t, outputStr, "アクティブなタスクはありません - すべて完了しています！")
-		assert.Contains(t, outputStr, "待機中のタスクはありません")
+		assert.Contains(t, outputStr, "No active tasks - all completed!")
+		assert.Contains(t, outputStr, "No pending tasks")
 	})
 
 	t.Run("Watch Flag Recognition", func(t *testing.T) {


### PR DESCRIPTION
## Overview

This PR addresses Issue #110 by replacing Japanese messages with English in the status command for consistency with the project's language policy.

## Changes Implemented ✅

### Status Command Messages
- ✅ Replaced 'アクティブなタスクはありません - すべて完了しています！' with 'No active tasks - all completed\!'
- ✅ Replaced '待機中のタスクはありません' with 'No pending tasks'
- ✅ Replaced 'アクティブなタスクはありません' with 'No active tasks'

### Test Updates
- ✅ Updated test assertions in `cmd/status_test.go` to match new English messages
- ✅ Added comprehensive test `TestEnglishMessagesInAIModeNoActiveTasks` to verify English messages display correctly
- ✅ Verified no Japanese messages appear in output

## Test Coverage

All tests pass successfully:
- Unit tests verify correct English messages in various scenarios
- Integration tests confirm proper behavior when no active or pending tasks exist
- Coverage includes edge cases for different task states

## Why This Change?

According to the project memory, system messages should be in English for consistency and international usage. This ensures the tool is accessible to a broader audience.

## Related

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status messages in AI mode are now displayed in English instead of Japanese.

* **Tests**
  * Updated and added tests to verify that English messages appear in AI mode output and Japanese messages are no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->