### PR TITLE
feat: Auto-cleanup closed PR directories during fetch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -164,6 +164,15 @@ func runReviewTask(cmd *cobra.Command, args []string) error {
 	// Initialize storage manager
 	storageManager := storage.NewManager()
 
+	// Auto-cleanup closed PRs
+	fmt.Println("Checking for closed PRs to clean up...")
+	if err := storageManager.CleanupClosedPRs(func(prNumber int) (bool, error) {
+		return ghClient.IsPROpen(ctx, prNumber)
+	}); err != nil {
+		// Don't fail the command if cleanup fails, just warn
+		fmt.Printf("Warning: Failed to cleanup closed PRs: %v\n", err)
+	}
+
 	// Determine PR number
 	var prNumber int
 	if len(args) > 0 {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -373,3 +373,14 @@ func (c *Client) GetTokenScopes() ([]string, error) {
 
 	return scopes, nil
 }
+
+// IsPROpen checks if a PR is open (not closed or merged)
+func (c *Client) IsPROpen(ctx context.Context, prNumber int) (bool, error) {
+	pr, _, err := c.client.PullRequests.Get(ctx, c.owner, c.repo, prNumber)
+	if err != nil {
+		return false, fmt.Errorf("failed to get PR #%d: %w", prNumber, err)
+	}
+
+	// PR is open if state is "open"
+	return pr.GetState() == "open", nil
+}


### PR DESCRIPTION
## Summary

This PR closes #11 by implementing automatic cleanup of closed/merged PR directories during the fetch command execution.

## Implementation Plan

- [ ] Add `CleanupClosedPRs` method to storage manager
- [ ] Add `IsPROpen` method to GitHub client  
- [ ] Integrate cleanup into fetch command workflow
- [ ] Display cleanup results to user
- [ ] Handle errors gracefully (skip PRs that can't be checked)

## Benefits

- Automatic storage management without manual intervention
- Prevents accumulation of old PR data
- Maintains cleaner project structure
- Improves developer experience

## Testing

- Unit tests for `CleanupClosedPRs` method
- Unit tests for `IsPROpen` method
- Integration tests for fetch command with cleanup functionality