### PR TITLE
feat: enhance cursor command with multiple template support and stdout option

### DIFF
--- a/cmd/cursor.go
+++ b/cmd/cursor.go
@@ -2,10 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	cursorAllFlag    bool
+	cursorStdoutFlag bool
 )
 
 var cursorCmd = &cobra.Command{
@@ -14,26 +20,55 @@ var cursorCmd = &cobra.Command{
 	Long: `Output command templates for Cursor IDE to .cursor/commands directory for better organization and discoverability.
 
 Available targets:
-  pr-review    Output PR review workflow command template to .cursor/commands/pr-review/
+  pr-review      Output PR review workflow command template
+  issue-to-pr    Output Issue-to-PR workflow command template
+  label-issues   Output Label Issues workflow command template
 
 Examples:
-  reviewtask cursor pr-review    # Output review-task-workflow command template for Cursor IDE`,
-	Args: cobra.ExactArgs(1),
+  reviewtask cursor pr-review          # Output review-task-workflow command template for Cursor IDE
+  reviewtask cursor issue-to-pr        # Output issue-to-pr workflow command template
+  reviewtask cursor label-issues       # Output label-issues workflow command template
+  reviewtask cursor --all              # Output all available command templates
+  reviewtask cursor pr-review --stdout # Output to standard output instead of files
+  reviewtask cursor --all --stdout     # Output all templates to standard output`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runCursor,
 }
 
 func init() {
 	// Command registration will be done in root.go
+	cursorCmd.Flags().BoolVar(&cursorAllFlag, "all", false, "Generate all available command templates")
+	cursorCmd.Flags().BoolVar(&cursorStdoutFlag, "stdout", false, "Output to standard output instead of files")
 }
 
 func runCursor(cmd *cobra.Command, args []string) error {
+	// If --all flag is set, generate all templates
+	if cursorAllFlag {
+		return outputAllCursorCommands(cmd.OutOrStdout())
+	}
+
+	// Require target argument if not using --all
+	if len(args) == 0 {
+		return fmt.Errorf("target argument required when not using --all flag\n\nAvailable targets:\n  pr-review      Output PR review workflow command template\n  issue-to-pr    Output Issue-to-PR workflow command template\n  label-issues   Output Label Issues workflow command template")
+	}
+
 	target := args[0]
 
+	// If --stdout flag is set, output to stdout
+	if cursorStdoutFlag {
+		return outputCursorCommandToStdout(cmd.OutOrStdout(), target)
+	}
+
+	// Default: output to files
 	switch target {
 	case "pr-review":
 		return outputCursorPRReviewCommands()
+	case "issue-to-pr":
+		return outputCursorIssueToPRCommands()
+	case "label-issues":
+		return outputCursorLabelIssuesCommands()
 	default:
-		return fmt.Errorf("unknown target: %s\n\nAvailable targets:\n  pr-review    Output PR review workflow command template", target)
+		return fmt.Errorf("unknown target: %s\n\nAvailable targets:\n  pr-review      Output PR review workflow command template\n  issue-to-pr    Output Issue-to-PR workflow command template\n  label-issues   Output Label Issues workflow command template", target)
 	}
 }
 
@@ -58,5 +93,99 @@ func outputCursorPRReviewCommands() error {
 	fmt.Println("Cursor IDE commands have been organized in .cursor/commands/pr-review/")
 	fmt.Println("You can now use the /review-task-workflow command in Cursor IDE.")
 
+	return nil
+}
+
+func outputCursorIssueToPRCommands() error {
+	// Create the output directory
+	outputDir := ".cursor/commands/issue-to-pr"
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", outputDir, err)
+	}
+
+	// Use the template content
+	workflowTemplate := getIssueToPRTemplate()
+
+	// Write the workflow template
+	workflowPath := filepath.Join(outputDir, "issue-to-pr.md")
+	if err := os.WriteFile(workflowPath, []byte(workflowTemplate), 0644); err != nil {
+		return fmt.Errorf("failed to write workflow template: %w", err)
+	}
+
+	fmt.Printf("✓ Created Cursor IDE command template at %s\n", workflowPath)
+	fmt.Println()
+	fmt.Println("Cursor IDE commands have been organized in .cursor/commands/issue-to-pr/")
+	fmt.Println("You can now use the /issue-to-pr command in Cursor IDE.")
+
+	return nil
+}
+
+func outputCursorLabelIssuesCommands() error {
+	// Create the output directory
+	outputDir := ".cursor/commands/label-issues"
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", outputDir, err)
+	}
+
+	// Use the template content
+	workflowTemplate := getLabelIssuesTemplate()
+
+	// Write the workflow template
+	workflowPath := filepath.Join(outputDir, "label-issues.md")
+	if err := os.WriteFile(workflowPath, []byte(workflowTemplate), 0644); err != nil {
+		return fmt.Errorf("failed to write workflow template: %w", err)
+	}
+
+	fmt.Printf("✓ Created Cursor IDE command template at %s\n", workflowPath)
+	fmt.Println()
+	fmt.Println("Cursor IDE commands have been organized in .cursor/commands/label-issues/")
+	fmt.Println("You can now use the /label-issues command in Cursor IDE.")
+
+	return nil
+}
+
+func outputAllCursorCommands(out io.Writer) error {
+	// If stdout flag is set, output all to stdout
+	if cursorStdoutFlag {
+		// Output all templates to stdout with clear separators
+		fmt.Fprintln(out, "# === PR REVIEW WORKFLOW ===")
+		fmt.Fprintln(out, getPRReviewPromptTemplate())
+		fmt.Fprintln(out, "\n# === ISSUE TO PR WORKFLOW ===")
+		fmt.Fprintln(out, getIssueToPRTemplate())
+		fmt.Fprintln(out, "\n# === LABEL ISSUES WORKFLOW ===")
+		fmt.Fprintln(out, getLabelIssuesTemplate())
+		return nil
+	}
+
+	// Generate all command templates to files
+	if err := outputCursorPRReviewCommands(); err != nil {
+		return err
+	}
+	if err := outputCursorIssueToPRCommands(); err != nil {
+		return err
+	}
+	if err := outputCursorLabelIssuesCommands(); err != nil {
+		return err
+	}
+
+	fmt.Println("\n✅ All Cursor IDE command templates have been generated successfully!")
+	return nil
+}
+
+func outputCursorCommandToStdout(out io.Writer, target string) error {
+	var template string
+
+	switch target {
+	case "pr-review":
+		template = getPRReviewPromptTemplate()
+	case "issue-to-pr":
+		template = getIssueToPRTemplate()
+	case "label-issues":
+		template = getLabelIssuesTemplate()
+	default:
+		return fmt.Errorf("unknown target: %s", target)
+	}
+
+	fmt.Fprint(out, template)
 	return nil
 }

--- a/cmd/prompt_stdout.go
+++ b/cmd/prompt_stdout.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -50,6 +51,30 @@ func outputPRReviewPromptToStdout(cmd *cobra.Command) error {
 
 // getPRReviewPromptTemplate returns the PR review workflow prompt template
 // This is shared between claude.go and prompt_stdout.go to maintain consistency
+func getIssueToPRTemplate() string {
+	// Read the issue-to-pr template content
+	templatePath := ".claude/commands/issue-to-pr.md"
+	if content, err := os.ReadFile(templatePath); err == nil {
+		return string(content)
+	}
+	// Return a fallback template if file not found
+	return `# Issue to PR Workflow
+
+Template file not found at .claude/commands/issue-to-pr.md`
+}
+
+func getLabelIssuesTemplate() string {
+	// Read the label-issues template content
+	templatePath := ".claude/commands/label-issues.md"
+	if content, err := os.ReadFile(templatePath); err == nil {
+		return string(content)
+	}
+	// Return a fallback template if file not found
+	return `# Label Issues
+
+Template file not found at .claude/commands/label-issues.md`
+}
+
 func getPRReviewPromptTemplate() string {
 	// Use § as placeholder for backticks to enable true heredoc format
 	template := `---


### PR DESCRIPTION
## Summary

This PR enhances the cursor command to support multiple command template generation, standard output option, and generation of all available templates. This completes the Cursor integration by providing full parity with the Claude command functionality.

Closes #65

## Changes

- ✅ Add support for multiple command template targets (pr-review, issue-to-pr, label-issues)
- ✅ Implement `--all` flag to generate all available command templates
- ✅ Add `--stdout` flag for outputting templates to standard output for CI/CD integration
- ✅ Maintain backward compatibility with existing cursor pr-review command
- ✅ Extract templates from existing `.claude/commands/` for consistency

## Testing

- [ ] Unit tests added for new cursor command functionality
- [ ] Integration tests verify template generation for all targets
- [ ] Manual testing of all command variations
- [ ] Documentation updated with new usage examples

## Current Implementation Progress

Based on PR #162 and Issue #65 requirements:
- ✅ Cursor CLI Integration (cursor-agent as AI provider) - from PR #162
- ✅ Basic cursor command generation (pr-review only) - from PR #162
- ✅ Multiple command template generation - **this PR**
- ✅ Standard output support - **this PR**
- ✅ Generate all commands option - **this PR**

## Command Structure

```
.cursor/
└── commands/
    ├── pr-review/         # PR review workflow (already implemented)
    ├── issue-to-pr/       # Issue to PR conversion workflow (new)
    └── label-issues/      # Label issues workflow (new)
```

## Usage Examples

```bash
# Generate specific template
reviewtask cursor pr-review
reviewtask cursor issue-to-pr
reviewtask cursor label-issues

# Generate all templates
reviewtask cursor --all

# Output to stdout for CI/CD
reviewtask cursor pr-review --stdout
reviewtask cursor --all --stdout
```

## Implementation Details

The implementation follows the same pattern as the existing Claude command:
- Templates are read from existing `.claude/commands/` directory to ensure consistency
- Supports both file output (default) and stdout output (with --stdout flag)
- The --all flag generates all available templates at once
- Maintains backward compatibility with the existing `cursor pr-review` command

## Next Steps

After this PR is merged:
1. Add unit and integration tests for the new functionality
2. Update documentation to reflect new cursor command capabilities
3. Consider adding template customization options in future iterations